### PR TITLE
Fetch and display pending github review requests. Fixes #5

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,6 @@ For Bugzilla, you'll need to generate an API key. Visit [the API keys](https://b
 
 Once you have that API key, go to about:addons and visit the Preferences for MyQOnly. Paste in the API key, and set the update interval to your liking.
 
+For Github, you just need to enter your username into the about:addons preferences in MyQOnly.
+
 This is still very much a WIP, so it might not work perfectly. Please file bugs!

--- a/content/options.html
+++ b/content/options.html
@@ -19,6 +19,9 @@
 
   <label for="phabricator-key">Bugzilla API Key</label>
   <input type="text" id="bugzilla-key" data-type="bugzilla"/>
+
+  <label for="github-username">Github Username</label>
+  <input type="text" id="github-username" data-type="ghuser">
 </section>
 
 <script src="options.js"></script>

--- a/content/options.js
+++ b/content/options.js
@@ -1,6 +1,7 @@
 const Options = {
   KEYS: [
     "bugzilla",
+    "ghuser"
   ],
 
   async init() {

--- a/content/popup.css
+++ b/content/popup.css
@@ -6,6 +6,7 @@ html, body {
 body:not([total-reviews="0"]) > #no-reviews,
 body[total-reviews="0"] > #has-reviews,
 body[total-phabricator-reviews="0"] > #phabricator-reviews,
-body[total-bugzilla-reviews="0"] > #bugzilla-reviews {
+body[total-bugzilla-reviews="0"] > #bugzilla-reviews,
+body[total-github-reviews="0"] > #github-reviews {
   display: none;
 }

--- a/content/popup.html
+++ b/content/popup.html
@@ -20,6 +20,10 @@
   <section id="bugzilla-reviews">
     <a href="https://bugzilla.mozilla.org/page.cgi?id=mydashboard.html"><span id="bugzilla-review-num"></span> reviews on Bugzilla</a>
   </section>
+
+  <section id="github-reviews">
+    <a href="https://github.com/pulls/review-requested"><span id="github-review-num"></span> reviews on Github</a>
+  </section>
 </body>
 
 <script src="popup.js"></script>

--- a/content/popup.js
+++ b/content/popup.js
@@ -1,14 +1,16 @@
 const Panel = {
   async init() {
     let reviews = await browser.runtime.sendMessage({ name: "get-reviews" });
-    let total = reviews.phabricator + reviews.bugzilla;
+    let total = reviews.phabricator + reviews.bugzilla + reviews.github;
     document.body.setAttribute("total-reviews", total);
     document.body.setAttribute("total-phabricator-reviews", reviews.phabricator);
     document.body.setAttribute("total-bugzilla-reviews", reviews.bugzilla);
+    document.body.setAttribute("total-github-reviews", reviews.github);
 
     document.getElementById("total-reviews").textContent = total;
     document.getElementById("phabricator-review-num").textContent = reviews.phabricator;
     document.getElementById("bugzilla-review-num").textContent = reviews.bugzilla;
+    document.getElementById("github-review-num").textContent = reviews.github;
   },
 };
 


### PR DESCRIPTION
Does what it says on the tin. Just requires the github username in the options, since for better or worse that call doesn't require auth.