### PR TITLE
Add support for working hours. Fixes #3

### DIFF
--- a/content/options.html
+++ b/content/options.html
@@ -22,6 +22,44 @@
 
   <label for="github-username">Github Username</label>
   <input type="text" id="github-username" data-type="ghuser">
+
+  <h1>Working Hours</h1>
+  <br>
+
+  <label for="working-hours-checkbox">Only show review count during working hours</label>
+  <input type="checkbox" id="working-hours-checkbox">
+
+  <fieldset id="working-hours" disabled>
+    <label for="start-time">Start time</label>
+    <input type="time" id="start-time" value="09:00">
+    <br>
+    <label for="end-time">End time</label>
+    <input type="time" id="end-time" value="17:00">
+
+    <div id="days">
+      <p>Working Days:</p>
+      <label for="sunday">Sunday</label>
+      <input type="checkbox" id="sunday">
+      <br>
+      <label for="monday">Monday</label>
+      <input type="checkbox" id="monday" checked>
+      <br>
+      <label for="tuesday">Tuesday</label>
+      <input type="checkbox" id="tuesday" checked>
+      <br>
+      <label for="wednesday">Wednesday</label>
+      <input type="checkbox" id="wednesday" checked>
+      <br>
+      <label for="thursday">Thursday</label>
+      <input type="checkbox" id="thursday" checked>
+      <br>
+      <label for="friday">Friday</label>
+      <input type="checkbox" id="friday" checked>
+      <br>
+      <label for="saturday">Saturday</label>
+      <input type="checkbox" id="saturday">
+    </div>
+  </fieldset>
 </section>
 
 <script src="options.js"></script>

--- a/content/options.js
+++ b/content/options.js
@@ -20,6 +20,34 @@ const Options = {
 
     let options = document.getElementById("options");
     options.addEventListener("change", this);
+
+    this.initWorkingHours();
+  },
+
+  async initWorkingHours() {
+    // Specify reasonable defaults for the first-run case.
+    let { workingHours } = await browser.storage.local.get({workingHours: {
+      enabled: false,
+      startTime: "09:00",
+      endTime: "17:00",
+      days: ["monday","tuesday","wednesday","thursday","friday"]
+    }});
+
+    document.querySelector("#working-hours-checkbox").checked = workingHours.enabled;
+    if (workingHours.enabled) {
+      document.querySelector("#working-hours").removeAttribute("disabled");
+    } else {
+      document.querySelector("#working-hours").setAttribute("disabled", "disabled");
+    }
+    document.querySelector("#start-time").value  = workingHours.startTime;
+    document.querySelector("#end-time").value    = workingHours.endTime;
+    document.querySelector("#sunday").checked    = workingHours.days.includes("sunday");
+    document.querySelector("#monday").checked    = workingHours.days.includes("monday");
+    document.querySelector("#tuesday").checked   = workingHours.days.includes("tuesday");
+    document.querySelector("#wednesday").checked = workingHours.days.includes("wednesday");
+    document.querySelector("#thursday").checked  = workingHours.days.includes("thursday");
+    document.querySelector("#friday").checked    = workingHours.days.includes("friday");
+    document.querySelector("#saturday").checked  = workingHours.days.includes("saturday");
   },
 
   handleEvent(e) {
@@ -34,7 +62,34 @@ const Options = {
       browser.storage.local.set({ "userKeys": this.userKeys }).then(() => {
         console.log(`Saved update to key type ${keyType}`);;
       });
+    } else if (e.target.id == "working-hours-checkbox" || e.target.closest("#working-hours")) {
+      this.onWorkingHoursChanged();
     }
+  },
+
+  onWorkingHoursChanged() {
+    console.log(`Working hours changed`);
+
+    let enabled = document.querySelector("#working-hours-checkbox").checked;
+    if (enabled) {
+      document.querySelector("#working-hours").removeAttribute("disabled");
+    } else {
+      document.querySelector("#working-hours").setAttribute("disabled", "disabled");
+    }
+
+    // Times are strings of the form "HH:MM" in 24-hour format (or empty string)
+    let startTime = document.querySelector("#start-time").value;
+    let endTime = document.querySelector("#end-time").value;
+
+    // `days` is an array containing en-US day strings: ['sunday', 'monday', ...]
+    let days = [].slice.call(document.querySelectorAll("#days input:checked"))
+                 .map(el => { return el.getAttribute("id")});
+
+    browser.storage.local.set({"workingHours": {enabled, days, startTime, endTime}}).then(() => {
+      console.log(`Saved update to working hours: enabled: ${enabled}, days: ${days.join(',')}, start time: ${startTime}, end time: ${endTime}`);
+    }).catch((err) => {
+      console.error(`Error updating working hours: ${err}`)
+    });
   }
 }
 


### PR DESCRIPTION
* Add day and time pickers to the options page

* Clear the review badge if the update interval runs outside the working hours

Here's the options page with the UI as implemented:

<img width="960" alt="screen shot 2018-10-18 at 12 33 16 pm" src="https://user-images.githubusercontent.com/96396/47179112-0eea4780-d2d2-11e8-957c-d1988ec16335.png">
