### PR TITLE
Let the 'refreshing' UI hang around for a beat

### DIFF
--- a/addon/content/popup/popup.js
+++ b/addon/content/popup/popup.js
@@ -49,7 +49,7 @@ const Panel = {
     let status = document.getElementById("status");
     status.textContent = "Refreshing...";
 
-    await new Promise(resolve => window.requestAnimationFrame(resolve));
+    await new Promise(resolve => window.setTimeout(resolve, 250));
 
     let reviews = await browser.runtime.sendMessage({ name: "get-reviews", });
     let total = reviews.phabricator + reviews.bugzilla + reviews.github;


### PR DESCRIPTION
The "Refreshing..." state goes by a little too quickly to serve as useful UI feedback ("Did I just press that button? Did it work?")

This PR switches to a 250ms setTimeout instead.

Fixes #21