### PR TITLE
Add a GitHub setting for ignoring your own PRs

### DIFF
--- a/addon/background.js
+++ b/addon/background.js
@@ -420,6 +420,9 @@ var MyQOnly = {
     // reason.
     let url = new URL(GITHUB_API);
     let query = `review-requested:${username} type:pr is:open archived:false`;
+    if (settings.ignoreOwnPrs) {
+      query += ` -author:${username}`;
+    }
     url.searchParams.set("q", query);
     // Note: we might need to paginate if we care about fetching more than the
     // first 100.

--- a/addon/content/options/options.html
+++ b/addon/content/options/options.html
@@ -48,6 +48,10 @@
   <div class="service-settings" data-type="github">
     <label for="github-username">Username</label>
     <input type="text" id="github-username" data-setting="username">
+    <div class="form-rows">
+      <input type="checkbox" id="github-ignore-self" data-setting="ignoreOwnPrs">
+      <label for="github-ignore-self">Ignore your own pull requests.</label>
+    </div>
   </div>
 </section>
 

--- a/addon/content/options/options.html
+++ b/addon/content/options/options.html
@@ -52,6 +52,8 @@
       <input type="checkbox" id="github-ignore-self" data-setting="ignoreOwnPrs">
       <label for="github-ignore-self">Ignore your own pull requests.</label>
     </div>
+    <input type="text" id="github-ignored-teams" data-setting="ignoredTeams">
+    <label for="github-ignored-teams">Comma-separated list of github teams to ignore.</label>
   </div>
 </section>
 

--- a/addon/content/options/options.js
+++ b/addon/content/options/options.js
@@ -81,6 +81,10 @@ const Options = {
     let ignoreOwnPrs =
       githubSettings.querySelector("[data-setting='ignoreOwnPrs']");
     ignoreOwnPrs.checked = !!service.settings.ignoreOwnPrs;
+
+    let ignoredTeams =
+      githubSettings.querySelector("[data-setting='ignoredTeams']");
+    ignoredTeams.value = service.settings.ignoredTeams || "";
   },
 
   onUpdateService(event, serviceType) {

--- a/addon/content/options/options.js
+++ b/addon/content/options/options.js
@@ -77,6 +77,10 @@ const Options = {
 
     let username = githubSettings.querySelector("[data-setting='username']");
     username.value = service.settings.username;
+
+    let ignoreOwnPrs =
+      githubSettings.querySelector("[data-setting='ignoreOwnPrs']");
+    ignoreOwnPrs.checked = !!service.settings.ignoreOwnPrs;
   },
 
   onUpdateService(event, serviceType) {


### PR DESCRIPTION
This is useful for cases where you request review from team that you happen to be on.

For example, in https://github.com/mozilla/application-services/ we require review from anybody on the mozilla/a-s-review team, but if members of this team (including myself) use this, it causes our own PRs to be listed as needing review.

It's a setting since I could imagine cases where it's not desired.