### PR TITLE
Add an option to scrape all Bugzilla flags.

### DIFF
--- a/addon/background.js
+++ b/addon/background.js
@@ -294,7 +294,7 @@ var MyQOnly = {
   async updateBugzilla(settings) {
     let apiKey = settings.apiKey;
     if (!apiKey) {
-      return { reviewTotal: 0, needinfoTotal: 0, };
+      return { review: 0, needinfo: 0, };
     }
 
     // I'm not sure how much of this is necessary - I just looked at what
@@ -326,19 +326,31 @@ var MyQOnly = {
     if (bugzillaData.error) {
       throw new Error(`Bugzilla request failed: ${bugzillaData.error.message}`);
     }
-    let reviewTotal =
+
+    if (settings.allBugzillaFlags) {
+      let flagCounts = {};
+      bugzillaData.result.result.requestee.map(f => {
+        if (!(f.type in flagCounts)) {
+          flagCounts[f.type] = 0;
+        }
+        flagCounts[f.type]++;
+      });
+      return flagCounts;
+    }
+
+    let review =
       bugzillaData.result.result.requestee.filter(f => {
         return f.type == "review";
       }).length;
 
-    let needinfoTotal = 0;
+    let needinfo = 0;
     if (settings.needinfos) {
-      needinfoTotal =bugzillaData.result.result.requestee.filter(f => {
+      needinfo = bugzillaData.result.result.requestee.filter(f => {
         return f.type == "needinfo";
       }).length;
     }
 
-    return { reviewTotal, needinfoTotal, };
+    return { review, needinfo, };
   },
 
   async updateGitHub(settings) {
@@ -495,7 +507,9 @@ var MyQOnly = {
       total += state.data.reviewTotal || 0;
 
       if (state.type == "bugzilla") {
-        total += state.data.needinfoTotal || 0;
+        for (let count of Object.values(state.data)) {
+          total += count;
+        }
       }
     }
 
@@ -521,10 +535,9 @@ var MyQOnly = {
         }
         case "bugzilla": {
           data = await this.updateBugzilla(service.settings);
-          console.log(`Found ${data.reviewTotal} Bugzilla reviews ` +
-                      "to do");
-          console.log(`Found ${data.needinfoTotal} Bugzilla needinfos ` +
-                      "to do");
+          for (let [flag, count] of Object.entries(data)) {
+            console.log(`Found ${count} Bugzilla ${flag}s to do`);
+          }
           break;
         }
         case "github": {

--- a/addon/content/options/options.html
+++ b/addon/content/options/options.html
@@ -39,6 +39,10 @@
     <label for="bugzilla-apiKey">API Key</label>
     <input type="password" id="bugzilla-apiKey" data-setting="apiKey"/>
     <div class="form-rows">
+      <input type="checkbox" id="bugzilla-allBugzillaFlags" data-setting="allBugzillaFlags">
+      <label for="bugzilla-allBugzillaFlags">Count all Bugzilla Flags (implies "Count open needinfos too")</label>
+    </div>
+    <div class="form-rows">
       <input type="checkbox" id="bugzilla-needinfos" data-setting="needinfos">
       <label for="bugzilla-needinfos">Count open needinfos too</label>
     </div>

--- a/addon/content/options/options.js
+++ b/addon/content/options/options.js
@@ -69,6 +69,10 @@ const Options = {
     let needinfos =
       bugzillaSettings.querySelector("[data-setting='needinfos']");
     needinfos.checked = !!service.settings.needinfos;
+
+    let allBugzillaFlags =
+      bugzillaSettings.querySelector("[data-setting='allBugzillaFlags']");
+    allBugzillaFlags.checked = !!service.settings.allBugzillaFlags;
   },
 
   populateGitHub(service) {

--- a/addon/content/popup/popup.css
+++ b/addon/content/popup/popup.css
@@ -52,16 +52,18 @@ header {
 }
 
 body[total-phabricator-reviews="0"] > #phabricator-reviews,
-body[total-bugzilla-reviews="0"] > #bugzilla-reviews,
-body[total-bugzilla-needinfos="0"] > #bugzilla-needinfos,
 body[total-github-reviews="0"] > #github-reviews,
 body:not([has-new-features]) > #has-new-features {
   display: none;
 }
 
-body > section,
+body section,
 body > h1 {
   margin: 15px;
+}
+
+#bugzilla-flags {
+  display: grid;
 }
 
 #has-new-features {

--- a/addon/content/popup/popup.html
+++ b/addon/content/popup/popup.html
@@ -17,13 +17,8 @@
     <a href="https://phabricator.services.mozilla.com/"><span id="phabricator-review-num"></span> review(s) on Phabricator</a>
   </section>
 
-  <section id="bugzilla-reviews">
-    <a href="https://bugzilla.mozilla.org/page.cgi?id=mydashboard.html"><span id="bugzilla-review-num"></span> review(s) on Bugzilla</a>
-  </section>
-
-  <section id="bugzilla-needinfos">
-    <a href="https://bugzilla.mozilla.org/page.cgi?id=mydashboard.html"><span id="bugzilla-needinfo-num"></span> needinfo(s) on Bugzilla</a>
-  </section>
+  <div id="bugzilla-flags">
+  </div>
 
   <section id="github-reviews">
     <a href="https://github.com/pulls/review-requested"><span id="github-review-num"></span> review(s) on Github</a>

--- a/addon/content/popup/popup.js
+++ b/addon/content/popup/popup.js
@@ -64,21 +64,27 @@ const Panel = {
       switch (state.type) {
       case "bugzilla": {
         let serviceTotal = 0;
-        if (state.data.reviewTotal) {
-          serviceTotal += state.data.reviewTotal;
-        }
-        if (state.data.needinfoTotal) {
-          serviceTotal += state.data.needinfoTotal;
-        }
+        let flagsElt = document.getElementById("bugzilla-flags");
+        flagsElt.innerHTML = "";
 
-        document.body.setAttribute("total-bugzilla-reviews",
-          state.data.reviewTotal || 0);
-        document.body.setAttribute("total-bugzilla-needinfos",
-          state.data.needinfoTotal || 0);
-        document.getElementById("bugzilla-review-num").textContent =
-          state.data.reviewTotal || 0;
-        document.getElementById("bugzilla-needinfo-num").textContent =
-          state.data.needinfoTotal || 0;
+        for (let [flag, count] of Object.entries(state.data)) {
+          serviceTotal += count;
+
+          document.body.setAttribute(`total-bugzilla-${flag}s`, count || 0);
+
+          if (!count || count === 0) {
+            continue;
+          }
+
+          let sectionElt = document.createElement("section");
+          sectionElt.id = "bugzilla-" + flag + "s";
+          let anchorElt = document.createElement("a");
+          anchorElt.href =
+            "https://bugzilla.mozilla.org/page.cgi?id=mydashboard.html";
+          anchorElt.textContent = `${count} ${flag}(s) on Bugzilla`;
+          sectionElt.appendChild(anchorElt);
+          flagsElt.appendChild(sectionElt);
+        }
 
         total += serviceTotal;
         break;

--- a/tests/content/options.test.js
+++ b/tests/content/options.test.js
@@ -176,6 +176,48 @@ describe("Options page", function() {
     });
   });
 
+  it("should be able to update the all flags state for Bugzilla", async () => {
+    await loadPage({
+      url: "/addon/content/options/options.html",
+      setup: setupWithServices,
+      test: async(content, document) => {
+        let field = document.getElementById("bugzilla-allBugzillaFlags");
+        field.checked.should.equal(false);
+
+        browser.storage.local.set.withArgs({ services: undefined, }).returns(
+          Promise.resolve()
+        );
+
+        // Now update the value
+        field.click();
+
+        assert.ok(browser.storage.local.set.calledOnce);
+        assert.ok(browser.storage.local.set.calledWith({
+          services: [{
+            id: 1,
+            type: "bugzilla",
+            settings: {
+              apiKey: "abc123",
+              allBugzillaFlags: true,
+            },
+          }, {
+            id: 2,
+            type: "github",
+            settings: {
+              username: "mikeconley",
+            },
+          }, {
+            id: 3,
+            type: "phabricator",
+            settings: {
+              container: 0,
+            },
+          },],
+        }));
+      },
+    });
+  });
+
   it("should show and be able to update the GitHub username", async () => {
     await loadPage({
       url: "/addon/content/options/options.html",


### PR DESCRIPTION
Fixes #26

There wasn't any UI code inside the onChange listener so I didn't make the
needinfo setting visually subordinate to the all flags setting. Instead it is
semantically subordinate.