### PR TITLE
Fixes #37 - save falsy checkbox values

### DIFF
--- a/addon/content/options/options.js
+++ b/addon/content/options/options.js
@@ -49,7 +49,7 @@ const Options = {
 
     let container =
       phabricatorSettings.querySelector("[data-setting='container']");
-    container.checked = service.settings.container !== undefined;
+    container.checked = !!service.settings.container;
 
     let inclReviewerGroups =
       phabricatorSettings.querySelector("[data-setting='inclReviewerGroups']");
@@ -114,7 +114,7 @@ const Options = {
 
     // For now, there's only a single service instance per type.
     let settings = this.getServiceSettings(serviceType);
-    if (newValue !== null) {
+    if (newValue !== undefined) {
       settings[changedSetting] = newValue;
     } else {
       delete settings[changedSetting];


### PR DESCRIPTION
The code in `_initServices()` uses `undefined` as expected -- to indicate that
a field doesn't exist. OTOH, when `onUpdateService` saves unchecked checkboxes,
it deletes their value from settings, which also results in `undefined`.

This patch changes that code such that a `newValue` of `undefined` does indeed
delete the value of the setting, but a falsy `newValue` is still written to
the settings.