### PR TITLE
Add option to ignore specific Github repos

### DIFF
--- a/addon/background.js
+++ b/addon/background.js
@@ -434,6 +434,7 @@ var MyQOnly = {
     let validPrs = data.total_count - data.items.length;
     for (let pr of data.items) {
       let prUrl = pr.pull_request.url;
+      let reviewers = [];
       let teams = [];
       if (!hitRateLimit) {
         let resp = await window.fetch(prUrl, apiRequestOptions);
@@ -443,6 +444,7 @@ var MyQOnly = {
         } else {
           if (resp.ok) {
             let respBody = await resp.json();
+            reviewers = respBody.requested_reviewers || [];
             teams = respBody.requested_teams || [];
           } else {
             // Don't treat a request failure here as fatal, just stop making
@@ -452,7 +454,10 @@ var MyQOnly = {
           }
         }
       }
-      if (teams.every(team => !ignoredTeams.has(team.name))) {
+      // If review was requested directly, always treat as a valid PR.
+      if (reviewers.some(reviewer => reviewer.login === username)) {
+        validPrs++;
+      } else if (teams.every(team => !ignoredTeams.has(team.name))) {
         validPrs++;
       }
     }

--- a/addon/background.js
+++ b/addon/background.js
@@ -420,7 +420,13 @@ var MyQOnly = {
         .map(s => s.trim())
         .filter(Boolean));
 
-    if (ignoredTeams.size === 0) {
+    let ignoredRepos = new Array(
+      (settings.ignoredRepos || "")
+        .split(",")
+        .map(s => s.trim())
+        .filter(Boolean));
+
+    if (ignoredTeams.size === 0 && ignoredRepos.length === 0) {
       return { reviewTotal: data.total_count, };
     }
     // Sadly, `-team-review-requested:` doesn't appear to work in the API, so we
@@ -457,7 +463,8 @@ var MyQOnly = {
       // If review was requested directly, always treat as a valid PR.
       if (reviewers.some(reviewer => reviewer.login === username)) {
         validPrs++;
-      } else if (teams.every(team => !ignoredTeams.has(team.name))) {
+      } else if (teams.every(team => !ignoredTeams.has(team.name)) &&
+                 ignoredRepos.every(repo => !prUrl.includes(repo))) {
         validPrs++;
       }
     }

--- a/addon/content/options/options.html
+++ b/addon/content/options/options.html
@@ -58,6 +58,8 @@
     </div>
     <label for="github-ignored-teams">Comma-separated list of github teams to ignore.</label>
     <input type="text" id="github-ignored-teams" data-setting="ignoredTeams">
+    <label for="github-ignored-repos">Comma-separated list of github repositories to ignore as a substring of the url (only applies when requested as part of a team).</label>
+    <input type="text" id="github-ignored-repos" data-setting="ignoredRepos">
   </div>
 </section>
 

--- a/addon/content/options/options.js
+++ b/addon/content/options/options.js
@@ -89,6 +89,10 @@ const Options = {
     let ignoredTeams =
       githubSettings.querySelector("[data-setting='ignoredTeams']");
     ignoredTeams.value = service.settings.ignoredTeams || "";
+
+    let ignoredRepos =
+      githubSettings.querySelector("[data-setting='ignoredRepos']");
+    ignoredRepos.value = service.settings.ignoredRepos || "";
   },
 
   onUpdateService(event, serviceType) {


### PR DESCRIPTION
Sometimes you might be part of team that gets requests across a wide range of repositories. Some of these repos might be relevant to you, and others not so much. This option allows users to specify a list of strings that will be checked as a substring in the URL. In this way you can skip by repo via `<user>/<repo>`, or entire orgs.

E.g:
`mozilla-mobile/fenix` would skip reviews on that repo. Or `mozilla-mobile` would skip reviews in the entire org.

This option only has an affect when the review is requested via a group. If the user was explicitly added, the request will show up no matter what.

Fixes #51