### PR TITLE
Fix regression breaking Github reviews

### DIFF
--- a/addon/background.js
+++ b/addon/background.js
@@ -425,8 +425,7 @@ var MyQOnly = {
         .map(s => s.trim())
         .filter(Boolean));
 
-    let ignoredRepos = new Array(
-      (settings.ignoredRepos || "")
+    let ignoredRepos = (settings.ignoredRepos || "")
         .split(",")
         .map(s => s.trim())
         .filter(Boolean));


### PR DESCRIPTION
This is a regression from PR #52

The expression:
```
(settings.ignoredRepos || "")
        .split(",")
        .map(s => s.trim())
        .filter(Boolean));
```

already returns an array, so wrapping it in `new Array` actually yields `[ [] ]`. This then causes `ignoredRepos.length === 0` to always evaluate to `false`. So whenever this setting is empty, we'd actually hide *all* Github reviews.