### PR TITLE
Add an option to ignore draft PRs

### DIFF
--- a/addon/background.js
+++ b/addon/background.js
@@ -384,8 +384,10 @@ var MyQOnly = {
 
   async updateGitHub(settings) {
     let username = settings.username;
+    let reviewUrl = new URL("https://github.com/pulls/review-requested");
+
     if (!username) {
-      return { reviewTotal: 0, };
+      return { reviewTotal: 0, reviewUrl: reviewUrl.toString(), };
     }
     let token = settings.token;
 
@@ -396,7 +398,13 @@ var MyQOnly = {
     if (settings.ignoreOwnPrs) {
       query += ` -author:${username}`;
     }
+    if (settings.ignoreDraftPrs) {
+      query += " draft:false";
+    }
     url.searchParams.set("q", query);
+    reviewUrl.searchParams.set("q", query);
+    reviewUrl = reviewUrl.toString();
+
     let headers = {
       Accept: "application/vnd.github.v3+json",
     };
@@ -431,7 +439,7 @@ var MyQOnly = {
       .filter(Boolean);
 
     if (ignoredTeams.size === 0 && ignoredRepos.length === 0) {
-      return { reviewTotal: data.total_count, };
+      return { reviewTotal: data.total_count, reviewUrl, };
     }
     // Sadly, `-team-review-requested:` doesn't appear to work in the API, so we
     // just fetch each PR. Unfortunately, there's a rate limit of 60 requests
@@ -472,7 +480,7 @@ var MyQOnly = {
         validPrs++;
       }
     }
-    return { reviewTotal: validPrs, };
+    return { reviewTotal: validPrs, reviewUrl, };
   },
 
   /**

--- a/addon/content/options/options.html
+++ b/addon/content/options/options.html
@@ -58,6 +58,10 @@
       <input type="checkbox" id="github-ignore-self" data-setting="ignoreOwnPrs">
       <label for="github-ignore-self">Ignore your own pull requests.</label>
     </div>
+    <div class="form-rows">
+      <input type="checkbox" id="github-ignore-draft" data-setting="ignoreDraftPrs">
+      <label for="github-ignore-draft">Ignore draft pull requests.</label>
+    </div>
     <label for="github-ignored-teams">Comma-separated list of github teams to ignore.</label>
     <input type="text" id="github-ignored-teams" data-setting="ignoredTeams">
     <label for="github-ignored-repos">Comma-separated list of github repositories to ignore as a substring of the url (only applies when requested as part of a team).</label>

--- a/addon/content/options/options.js
+++ b/addon/content/options/options.js
@@ -89,6 +89,10 @@ const Options = {
       githubSettings.querySelector("[data-setting='ignoreOwnPrs']");
     ignoreOwnPrs.checked = !!service.settings.ignoreOwnPrs;
 
+    let ignoreDraftPrs =
+      githubSettings.querySelector("[data-setting='ignoreDraftPrs']");
+    ignoreDraftPrs.checked = !!service.settings.ignoreDraftPrs;
+
     let ignoredTeams =
       githubSettings.querySelector("[data-setting='ignoredTeams']");
     ignoredTeams.value = service.settings.ignoredTeams || "";

--- a/addon/content/popup/popup.html
+++ b/addon/content/popup/popup.html
@@ -30,7 +30,7 @@
   </section>
 
   <section id="github-reviews">
-    <a href="https://github.com/pulls/review-requested"><span id="github-review-num"></span> review(s) on Github</a>
+    <a id="github-review-link" href="https://github.com/pulls/review-requested"><span id="github-review-num"></span> review(s) on Github</a>
   </section>
 
   <a id="has-new-features" target="_blank" href="/content/release-notes/release-notes.html">

--- a/addon/content/popup/popup.js
+++ b/addon/content/popup/popup.js
@@ -119,10 +119,12 @@ const Panel = {
       }
       case "github": {
         let serviceTotal = state.data.reviewTotal || 0;
+        let reviewUrl = state.data.reviewUrl || "https://github.com/pulls/review-requested";
         document.body.setAttribute("total-github-reviews",
           serviceTotal || 0);
         document.getElementById("github-review-num").textContent =
           serviceTotal || 0;
+        document.getElementById("github-review-link").href = reviewUrl;
 
         total += serviceTotal;
         break;


### PR DESCRIPTION
This works similarly to the `ignoreOwnPrs` option. But it also adjusts the link that popup.html will send you to (this benefits both `ignoreDraftPrs` and `ignoreOwnPrs`).