### PR TITLE
Update Phabricator review links

### DIFF
--- a/addon/content/popup/popup.html
+++ b/addon/content/popup/popup.html
@@ -14,11 +14,11 @@
   <div id="phabricator-disconnected" class="hidden">Warning: Not logged in to Phabricator</div>
 
   <section id="phabricator-user-reviews">
-    <a href="https://phabricator.services.mozilla.com/differential"><span id="phabricator-user-review-num"></span> review(s) on Phabricator</a>
+    <a href="https://phabricator.services.mozilla.com/differential/query/active/"><span id="phabricator-user-review-num"></span> review(s) on Phabricator</a>
   </section>
 
   <section id="phabricator-group-reviews">
-    <a href="https://phabricator.services.mozilla.com/differential"><span id="phabricator-group-review-num"></span> reviewer group review(s) on Phabricator</a>
+    <a href="https://phabricator.services.mozilla.com/differential/query/active/"><span id="phabricator-group-review-num"></span> reviewer group review(s) on Phabricator</a>
   </section>
 
   <section id="bugzilla-reviews">


### PR DESCRIPTION
Changed the Phabricator review links in the popup to point directly to the "Active Revisions" query instead of the default query. The general differential URL depends on the default query selected in [Saved Queries](https://phabricator.services.mozilla.com/differential/query/edit/) settings. In my case, the default query was not the "Active Revisions" query.