### PR TITLE
feat!: add ignored repositories to the Github review filter

### DIFF
--- a/addon/background.js
+++ b/addon/background.js
@@ -391,6 +391,11 @@ var MyQOnly = {
     }
     let token = settings.token;
 
+    let ignoredRepos = (settings.ignoredRepos || "")
+      .split(",")
+      .map(s => s.trim())
+      .filter(Boolean);
+
     // We don't seem to need authentication for this request, for whatever
     // reason.
     let url = new URL(GITHUB_API);
@@ -408,6 +413,9 @@ var MyQOnly = {
     }
     if (settings.ignoreDraftPrs) {
       query += " draft:false";
+    }
+    for (let repo of ignoredRepos) {
+      query += ` -repo:${repo}`;
     }
     url.searchParams.set("q", query);
     reviewUrl.searchParams.set("q", query);
@@ -440,11 +448,6 @@ var MyQOnly = {
         .split(",")
         .map(s => s.trim())
         .filter(Boolean));
-
-    let ignoredRepos = (settings.ignoredRepos || "")
-      .split(",")
-      .map(s => s.trim())
-      .filter(Boolean);
 
     if (ignoredTeams.size === 0 && ignoredRepos.length === 0) {
       return { reviewTotal: data.total_count, reviewUrl, };
@@ -484,7 +487,7 @@ var MyQOnly = {
       if (reviewers.some(reviewer => reviewer.login === username)) {
         validPrs++;
       } else if (teams.every(team => !ignoredTeams.has(team.name)) &&
-                 ignoredRepos.every(repo => !prUrl.includes(repo))) {
+                 ignoredRepos.every(repo => !pr.repository_url.endsWith(`/${repo}`))) {
         validPrs++;
       }
     }

--- a/addon/content/options/options.html
+++ b/addon/content/options/options.html
@@ -66,7 +66,7 @@
     <input type="text" id="github-ignored-users" data-setting="ignoredUsers">
     <label for="github-ignored-teams">Comma-separated list of github teams to ignore requests for.</label>
     <input type="text" id="github-ignored-teams" data-setting="ignoredTeams">
-    <label for="github-ignored-repos">Comma-separated list of github repositories to ignore as a substring of the url (only applies when requested as part of a team).</label>
+    <label for="github-ignored-repos">Comma-separated list of github repositories to ignore in the form &lt;owner&gt;/&lt;repo&gt; (only applies when requested as part of a team).</label>
     <input type="text" id="github-ignored-repos" data-setting="ignoredRepos">
   </div>
 </section>


### PR DESCRIPTION
BREAKING CHANGE: Github ignored repo list now requires exact match on repo/owner rather than substring of the url.

I discovered you can do `-repo:<org>/<repo>` in the Github PR filter. This helps keep the Github view in sync with the number myqonly displays.

In order for this to work, we need to change to exact match rather of the owner/repo rather than a substring match.