### PR TITLE
Issue #101 - Use the Bugzilla REST API instead of the removed JSON-RPC endpoint

### DIFF
--- a/addon/constants.mjs
+++ b/addon/constants.mjs
@@ -10,12 +10,10 @@ export const PHABRICATOR_SELECTORS = {
   LINK_PERSON: ".phui-link-person"
 };
 
-export const BUGZILLA_API = "https://bugzilla.mozilla.org/jsonrpc.cgi";
+export const BUGZILLA_API =
+  "https://bugzilla.mozilla.org/rest/mydashboard/run_flag_query";
 export const BUGZILLA_DASHBOARD =
   "https://bugzilla.mozilla.org/page.cgi?id=mydashboard.html";
-export const BUGZILLA_METHOD = "MyDashboard.run_flag_query";
-export const BUGZILLA_REQUEST_ID = 4;
-export const BUGZILLA_VERSION = "1.1";
 
 export const GITHUB_API = "https://api.github.com/search/issues";
 export const GITHUB_REVIEW_URL = "https://github.com/pulls/review-requested";
@@ -45,8 +43,7 @@ export const MESSAGE_TYPES = {
 };
 
 export const HTTP_HEADERS = {
-  CONTENT_TYPE_HTML: "text/html",
-  CONTENT_TYPE_JSON: "application/json"
+  CONTENT_TYPE_HTML: "text/html"
 };
 
 export const HTTP_METHODS = {

--- a/addon/services/bugzilla-service.mjs
+++ b/addon/services/bugzilla-service.mjs
@@ -2,17 +2,13 @@ import { BaseService } from "./base-service.mjs";
 import {
   BUGZILLA_API,
   BUGZILLA_DASHBOARD,
-  BUGZILLA_METHOD,
-  BUGZILLA_REQUEST_ID,
-  BUGZILLA_VERSION,
   SERVICE_TYPES,
-  HTTP_METHODS,
-  HTTP_HEADERS
+  HTTP_METHODS
 } from "../constants.mjs";
 
 /**
  * Service for fetching Bugzilla review and needinfo counts.
- * Uses the Bugzilla JSON-RPC API to fetch flags requested from the user.
+ * Uses the Bugzilla REST API to fetch flags requested from the user.
  */
 export class BugzillaService extends BaseService {
   /**
@@ -29,42 +25,39 @@ export class BugzillaService extends BaseService {
       return { reviewTotal: 0, needinfoTotal: 0 };
     }
 
-    // I'm not sure how much of this is necessary - I just looked at what
-    // the Bugzilla My Dashboard thing does in the network inspector, and
-    // I'm more or less mimicking that here.
-    let body = JSON.stringify({
-      id: BUGZILLA_REQUEST_ID,
-      method: BUGZILLA_METHOD,
-      params: {
-        Bugzilla_api_key: apiKey,
-        type: "requestee"
-      },
-      version: BUGZILLA_VERSION
-    });
+    // "requestee" returns the flags awaiting a response from this user.
+    let url = new URL(BUGZILLA_API);
+    url.searchParams.set("type", "requestee");
 
-    let req = new Request(BUGZILLA_API, {
-      method: HTTP_METHODS.POST,
+    let req = new Request(url, {
+      method: HTTP_METHODS.GET,
       headers: {
-        "Content-Type": HTTP_HEADERS.CONTENT_TYPE_JSON
+        "X-BUGZILLA-API-KEY": apiKey
       },
-      body,
       credentials: "omit",
       redirect: "follow",
       referrer: "client"
     });
 
     let resp = await window.fetch(req);
+    if (!resp.ok) {
+      throw new Error(
+        `Bugzilla request failed (${resp.status}): ${await resp.text()}`
+      );
+    }
+
     let bugzillaData = await resp.json();
     if (bugzillaData.error) {
-      throw new Error(`Bugzilla request failed: ${bugzillaData.error.message}`);
+      throw new Error(`Bugzilla request failed: ${bugzillaData.message}`);
     }
-    let reviewTotal = bugzillaData.result.result.requestee.filter((f) => {
+
+    let reviewTotal = bugzillaData.result.requestee.filter((f) => {
       return f.type == "review";
     }).length;
 
     let needinfoTotal = 0;
     if (settings.needinfos) {
-      needinfoTotal = bugzillaData.result.result.requestee.filter((f) => {
+      needinfoTotal = bugzillaData.result.requestee.filter((f) => {
         return f.type == "needinfo";
       }).length;
     }

--- a/tests/services/bugzilla/bugzilla.test.mjs
+++ b/tests/services/bugzilla/bugzilla.test.mjs
@@ -2,9 +2,7 @@ import { BugzillaService } from "../../../addon/services/bugzilla-service.mjs";
 import {
   BUGZILLA_API,
   BUGZILLA_DASHBOARD,
-  BUGZILLA_METHOD,
-  BUGZILLA_REQUEST_ID,
-  BUGZILLA_VERSION,
+  HTTP_METHODS,
   SERVICE_TYPES
 } from "../../../addon/constants.mjs";
 import {
@@ -91,18 +89,21 @@ describe("Bugzilla Service", function () {
         await bugzillaService.update(settings);
         assert.fail("Should have thrown an error");
       } catch (error) {
-        assert.ok(error.message.includes("Invalid API key"));
+        assert.ok(
+          error.message.includes("The API key you specified is invalid")
+        );
       }
     });
 
-    it("should use correct JSON-RPC request format", async function () {
-      let capturedBody;
+    it("should use correct REST request format", async function () {
+      let capturedRequest;
 
       sandbox.stub(window, "fetch").callsFake(async (request) => {
-        capturedBody = await request.text();
+        capturedRequest = request;
 
         return {
           ok: true,
+          status: 200,
           json: async () => fixtures.bugzilla.apiEmptyResponse
         };
       });
@@ -110,12 +111,33 @@ describe("Bugzilla Service", function () {
       let settings = { apiKey: "test-key", needinfos: false };
       await bugzillaService.update(settings);
 
-      let body = JSON.parse(capturedBody);
-      assert.equal(body.method, BUGZILLA_METHOD);
-      assert.equal(body.params.Bugzilla_api_key, "test-key");
-      assert.equal(body.params.type, "requestee");
-      assert.equal(body.version, BUGZILLA_VERSION);
-      assert.equal(body.id, BUGZILLA_REQUEST_ID);
+      let url = new URL(capturedRequest.url);
+      assert.equal(capturedRequest.method, HTTP_METHODS.GET);
+      assert.equal(`${url.origin}${url.pathname}`, BUGZILLA_API);
+      assert.equal(url.searchParams.get("type"), "requestee");
+      assert.equal(
+        capturedRequest.headers.get("X-BUGZILLA-API-KEY"),
+        "test-key"
+      );
+      assert.equal(url.searchParams.get("Bugzilla_api_key"), null);
+    });
+
+    it("should throw when the endpoint returns a non-2xx response", async function () {
+      sandbox.stub(window, "fetch").resolves({
+        ok: false,
+        status: 404,
+        text: async () => "<!DOCTYPE html><title>Page Not Found</title>"
+      });
+
+      let settings = { apiKey: "test-key", needinfos: true };
+
+      try {
+        await bugzillaService.update(settings);
+        assert.fail("Should have thrown an error");
+      } catch (error) {
+        assert.ok(error.message.includes("404"));
+        assert.ok(error.message.includes("Page Not Found"));
+      }
     });
   });
 

--- a/tests/test-utils.mjs
+++ b/tests/test-utils.mjs
@@ -95,45 +95,40 @@ const fixtures = {
   bugzilla: {
     apiSuccessResponse: {
       result: {
-        result: {
-          requestee: [
-            {
-              id: 1,
-              bug_id: 123456,
-              type: "review",
-              status: "?",
-              requestee: "reviewer@example.com"
-            },
-            {
-              id: 2,
-              bug_id: 123456,
-              type: "needinfo",
-              status: "?",
-              requestee: "reviewer@example.com"
-            },
-            {
-              id: 3,
-              bug_id: 789012,
-              type: "review",
-              status: "?",
-              requestee: "reviewer@example.com"
-            }
-          ]
-        }
+        requestee: [
+          {
+            id: 1,
+            bug_id: 123456,
+            type: "review",
+            status: "?",
+            requestee: "reviewer@example.com"
+          },
+          {
+            id: 2,
+            bug_id: 123456,
+            type: "needinfo",
+            status: "?",
+            requestee: "reviewer@example.com"
+          },
+          {
+            id: 3,
+            bug_id: 789012,
+            type: "review",
+            status: "?",
+            requestee: "reviewer@example.com"
+          }
+        ]
       }
     },
     apiEmptyResponse: {
       result: {
-        result: {
-          requestee: []
-        }
+        requestee: []
       }
     },
     apiErrorResponse: {
-      error: {
-        code: 32000,
-        message: "Invalid API key"
-      }
+      error: true,
+      code: 306,
+      message: "The API key you specified is invalid."
     }
   },
   github: {


### PR DESCRIPTION
Fixes #101.

## What broke

`bugzilla.mozilla.org` removed `jsonrpc.cgi` in the `20260805.1` deploy. MyQOnly posts `MyDashboard.run_flag_query` to that endpoint, so it now gets an HTML 404 back. `resp.json()` throws a `SyntaxError`, the per-service `catch` in `updateBadge()` swallows it, and the Bugzilla state keeps its default — so Bugzilla review *and* needinfo counts both silently read zero. Anyone whose badge still looked plausible was seeing only Phabricator/GitHub counts.

## Why it changed

The removal is deliberate and long-planned, tracked by [bug 1599274 — \[META\] Deprecate XMLRPC/JSONRPC API and support only REST going forward](https://bugzilla.mozilla.org/show_bug.cgi?id=1599274), filed in 2019:

> Removing the old APIs may give performance gains but mainly reduce any future maintenance of that code.
>
> JSONRPC is mostly unused as all use of it by the WebUI has been removed and was never really used by external clients much.

It landed last week:

| Bug | What | Landed |
|---|---|---|
| [2057235](https://bugzilla.mozilla.org/show_bug.cgi?id=2057235) | Remove XMLRPC API support | 2026-08-03 |
| [2057238](https://bugzilla.mozilla.org/show_bug.cgi?id=2057238) | Remove the BzAPI extension | 2026-08-04 |
| [2058158](https://bugzilla.mozilla.org/show_bug.cgi?id=2058158) | Remove jsonrpc.cgi and disallow the JSONRPC endpoint | 2026-08-04 ([PR #2691](https://github.com/mozilla-bteam/bmo/pull/2691)) |

## The fix

Only the transport went away. The method is still registered as a REST route in [`MyDashboard/lib/WebService.pm`](https://github.com/mozilla-bteam/bmo/blob/master/extensions/MyDashboard/lib/WebService.pm):

```perl
qr{^/mydashboard/run_flag_query$}, {GET => {method => 'run_flag_query'}},
...
return {result => {$type => $results}};
```

Same method, same flag objects (`type` is still `review` / `needinfo`). So:

- `BUGZILLA_API` → `https://bugzilla.mozilla.org/rest/mydashboard/run_flag_query`
- `GET ?type=requestee`, with the key in an `X-BUGZILLA-API-KEY` header instead of a POST body
- `bugzillaData.result.requestee` — REST omits the extra `result` layer that JSON-RPC wrapped around the return value
- REST reports failures as a flat `{error: true, code, message}`; the old code read `.error.message`, which would itself have thrown
- Dropped the now-unused `BUGZILLA_METHOD` / `BUGZILLA_REQUEST_ID` / `BUGZILLA_VERSION`, and `HTTP_HEADERS.CONTENT_TYPE_JSON`
- Check `resp.ok` before parsing, matching `github-service.mjs`. This failure would then have read `Bugzilla request failed (404): <!DOCTYPE html>...` rather than an opaque `SyntaxError`

Existing `host_permissions` already cover the new path, so there's no manifest change and nothing for users to reconfigure.

## Worth watching

[Bug 2057358 — Migrate remaining REST resources to native Mojo API](https://bugzilla.mozilla.org/show_bug.cgi?id=2057358) is still open, and `/rest/mydashboard/run_flag_query` is exactly the sort of legacy `rest_resources` route it covers. This endpoint may move again.

## Testing

- `yarn test` — 117 passing. Bugzilla fixtures updated to the REST shape, the JSON-RPC request-format test replaced with a REST equivalent, and a non-2xx case added.
- `yarn lint` clean.
- Verified against live BMO that the route exists and header auth is reached — a bogus key returns `{"code":306,"message":"The API key you specified is invalid..."}`.
- Verified manually via Load Temporary Add-on with a real API key: needinfo count is correct again.

@mikeconley for review, per CONTRIBUTING.

---

This change was written with assistance from Claude, then manually reviewed and tested against a live Bugzilla account before submitting.
